### PR TITLE
test: add Home heading test using React Testing Library

### DIFF
--- a/calbooking/src/App.test.js
+++ b/calbooking/src/App.test.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import App from './App';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+it('renders Home heading', () => {
+  const { unmount } = render(<App />);
+  expect(
+    screen.getByRole('heading', { name: /home/i })
+  ).toBeInTheDocument();
+  unmount();
 });


### PR DESCRIPTION
## Summary
- use React Testing Library in `App.test.js`
- assert that Home heading renders

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_6899c3a0e940832686e415c7c14d82c3