### PR TITLE
Move react-router-dom to production dependencies

### DIFF
--- a/calbooking/package.json
+++ b/calbooking/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
+    "react-router-dom": "^4.3.1",
     "react-scripts": "5.0.1"
   },
   "scripts": {
@@ -12,9 +13,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
-  },
-  "devDependencies": {
-    "react-router-dom": "^4.3.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- move react-router-dom from devDependencies to dependencies

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c39e53cc83269f384f83fa64dc3f